### PR TITLE
(feat) Add options to hide term buffers and retry last target on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Default options:
         notify_on_success = true,
         -- Print warning if pane list could not be fetched, e.g. tmux not running.
         warn_tmux_not_running = false,
+        -- Retries the last used target if the target is unavailable (e.g., tmux pane closed). 
+        -- Useful for maintaining workflow without re-selecting the target manually.
+        -- Works with: term buffers, tmux panes, tmux windows
+        retry_last_target_on_failure = false,
+        -- Hide neovim term buffers in `yeet.select_target`
+        hide_term_buffers = false,
         -- Resolver for cache file
         cache = function()
            -- resolves project path and uses stdpath("cache")/yeet/<project>, see :h yeet

--- a/doc/yeet.txt
+++ b/doc/yeet.txt
@@ -12,14 +12,16 @@ SETUP                                                               *yeet-setup*
 Options                                                           *yeet.Options*
 
     Fields: ~
-        {yeet_and_run?}           (boolean)            Execute command immediately.
-        {clear_before_yeet?}      (boolean)            Clear buffer before execution.
-        {interrupt_before_yeet?}  (boolean)            Hit C-c before execution.
-        {notify_on_success?}      (boolean)            Print success notifications.
-        {warn_tmux_not_running?}  (boolean)            Print warning message if tmux is not up.
-        {use_cache_file?}         (boolean)            Use cache-file for persisting commands.
-        {cache?}                  (fun():string)       Resolver for cache file.
-        {cache_window_opts?}      (table|fun():table)  win_config passed to |nvim_open_win()|
+        {yeet_and_run?}                  (boolean)            Execute command immediately.
+        {clear_before_yeet?}             (boolean)            Clear buffer before execution.
+        {interrupt_before_yeet?}         (boolean)            Hit C-c before execution.
+        {notify_on_success?}             (boolean)            Print success notifications.
+        {warn_tmux_not_running?}         (boolean)            Print warning message if tmux is not up.
+        {retry_last_target_on_failure?}  (boolean)            Retries last target in case of failure. This only works for "new buffer term", "new tmux pane", "new tmux window"
+        {hide_term_buffers?}             (boolean)            Hide neovim terminal buffers in `yeet.select_target`
+        {use_cache_file?}                (boolean)            Use cache-file for persisting commands.
+        {cache?}                         (fun():string)       Resolver for cache file.
+        {cache_window_opts?}             (table|fun():table)  win_config passed to |nvim_open_win()|
 
     See: ~
         |standard-path|
@@ -100,7 +102,8 @@ M.execute({cmd?}, {opts?})                                        *yeet.execute*
     |yeet.set_cmd| or |yeet.list_cmd| for command.
 
     Prefix command with `C-c` to send interrupt before entering command.
-    Prefix command with `init:` to run command only if target is new.
+    Prefix command with `init:` to run command only if target is newly created
+    from target selection prompt.
 
     Options given are used for only this invocation, options registered
     in setup are not modified permanently.
@@ -203,14 +206,16 @@ CONF                                                                 *yeet-conf*
 Config                                                        *yeet-conf.Config*
 
     Fields: ~
-        {yeet_and_run}           (boolean)
-        {interrupt_before_yeet}  (boolean)
-        {clear_before_yeet}      (boolean)
-        {notify_on_success}      (boolean)
-        {warn_tmux_not_running}  (boolean)
-        {use_cache_file}         (boolean)
-        {cache}                  (fun():string)
-        {cache_window_opts}      (vim.api.keyset.win_config|fun():vim.api.keyset.win_config)
+        {yeet_and_run}                  (boolean)
+        {interrupt_before_yeet}         (boolean)
+        {clear_before_yeet}             (boolean)
+        {notify_on_success}             (boolean)
+        {warn_tmux_not_running}         (boolean)
+        {hide_term_buffers}             (boolean)
+        {retry_last_target_on_failure}  (boolean)
+        {use_cache_file}                (boolean)
+        {cache}                         (fun():string)
+        {cache_window_opts}             (vim.api.keyset.win_config|fun():vim.api.keyset.win_config)
 
 
 C.git_root({fallback?})                                     *yeet-conf.git_root*

--- a/lua/yeet/conf.lua
+++ b/lua/yeet/conf.lua
@@ -7,7 +7,7 @@
 ---@field notify_on_success boolean
 ---@field warn_tmux_not_running boolean
 ---@field hide_term_buffers boolean
----@field default_target? string
+---@field retry_last_target_on_failure boolean
 ---@field use_cache_file boolean
 ---@field cache fun():string
 ---@field cache_window_opts vim.api.keyset.win_config | fun():vim.api.keyset.win_config
@@ -123,8 +123,8 @@ C.defaults = {
     clear_before_yeet = true,
     notify_on_success = check_notify_overrides(),
     warn_tmux_not_running = false,
+    retry_last_target_on_failure = false,
     hide_term_buffers = false,
-    default_target = nil,
     cache = C.cachepath,
     use_cache_file = true,
     cache_window_opts = function()

--- a/lua/yeet/conf.lua
+++ b/lua/yeet/conf.lua
@@ -6,6 +6,8 @@
 ---@field clear_before_yeet boolean
 ---@field notify_on_success boolean
 ---@field warn_tmux_not_running boolean
+---@field hide_term_buffers boolean
+---@field default_target? string
 ---@field use_cache_file boolean
 ---@field cache fun():string
 ---@field cache_window_opts vim.api.keyset.win_config | fun():vim.api.keyset.win_config
@@ -121,6 +123,8 @@ C.defaults = {
     clear_before_yeet = true,
     notify_on_success = check_notify_overrides(),
     warn_tmux_not_running = false,
+    hide_term_buffers = false,
+    default_target = nil,
     cache = C.cachepath,
     use_cache_file = true,
     cache_window_opts = function()

--- a/lua/yeet/init.lua
+++ b/lua/yeet/init.lua
@@ -26,6 +26,8 @@ local M = {
 ---@field interrupt_before_yeet? boolean Hit C-c before execution.
 ---@field notify_on_success? boolean Print success notifications.
 ---@field warn_tmux_not_running? boolean Print warning message if tmux is not up.
+---@field hide_term_buffers? boolean Hide neovim terminal buffers in `yeet.select_target`
+---@field default_target? string Define a default target ("tmuxpane", "tmuxwindow")
 ---@field use_cache_file? boolean Use cache-file for persisting commands.
 ---@field cache? fun():string Resolver for cache file.
 ---@field cache_window_opts? table | fun():table win_config passed to |nvim_open_win()|
@@ -133,14 +135,21 @@ end
 
 ---@return Target[]
 local function refresh_targets()
-    local options = {
-        { type = "new_term", name = "[create new term buffer]", channel = 0 },
-    }
+    local options = {}
+
+    if not M.config.hide_term_buffers then
+        table.insert(options, { type = "new_term", name = "[create new term buffer]", channel = 0 })
+    end
 
     if os.getenv("TMUX") ~= nil then
         table.insert(
             options,
-            { type = "new_tmux", name = "[create new tmux pane]", channel = 0 }
+            { type = "new_tmux_pane", name = "[create new tmux pane]", channel = 0 }
+        )
+
+        table.insert(
+            options,
+            { type = "new_tmux_window", name = "[create new tmux window]", channel = 0 }
         )
     end
     for _, v in ipairs(buffer.get_channels()) do
@@ -187,8 +196,10 @@ function M.select_target(callback)
 
         if choice.type == "new_term" then
             set_target(buffer.new())
-        elseif choice.type == "new_tmux" then
-            set_target(tmux.new())
+        elseif choice.type == "new_tmux_pane" then
+            set_target(tmux.new_pane())
+        elseif choice.type == "new_tmux_window" then
+            set_target(tmux.new_window())
         else
             log("_set_target", choice)
             set_target(choice)

--- a/lua/yeet/tmux.lua
+++ b/lua/yeet/tmux.lua
@@ -119,7 +119,7 @@ local listpanefmt = "#D #{session_name}:#{window_index}.#{pane_index} "
 
 ---Create new tmux pane in vertical split.
 ---@return Target
-function M.new()
+function M.new_pane()
     local target = {}
     M._job("tmux split-window -dhPF '#D'", function(_, data, _)
         for _, line in ipairs(data) do
@@ -129,8 +129,29 @@ function M.new()
                 target = {
                     channel = channel,
                     type = "tmux",
-                    name = "[tmux] new",
-                    shortname = "[tmux] new",
+                    name = "[tmux] new pane",
+                    shortname = "[tmux] newp",
+                    new = true,
+                }
+            end
+        end
+    end, false)
+    return target
+end
+
+-- Create new tmux window in the current session
+function M.new_window()
+    local target = {}
+    M._job("tmux new-window -dPF '#D'", function(_, data, _)
+        for _, line in ipairs(data) do
+            local channel = line:match("^%%(%d+)")
+            if channel ~= nil then
+                ---@type Target
+                target = {
+                    channel = channel,
+                    type = "tmux",
+                    name = "[tmux] new window",
+                    shortname = "[tmux] neww",
                     new = true,
                 }
             end

--- a/tests/plenary/tmux_capture_spec.lua
+++ b/tests/plenary/tmux_capture_spec.lua
@@ -14,7 +14,7 @@ yeet.setup({
 
 describe("tmux target", function()
     local tmux = require("yeet.tmux")
-    local target = tmux.new()
+    local target = tmux.new_pane()
     yeet._target = target
 
     vim.system({

--- a/tests/plenary/tmux_spec.lua
+++ b/tests/plenary/tmux_spec.lua
@@ -12,7 +12,7 @@ yeet.setup({
 
 describe("tmux target", function()
     local tmux = require("yeet.tmux")
-    local target = tmux.new()
+    local target = tmux.new_pane()
     yeet._target = target
 
     vim.system({


### PR DESCRIPTION
This PR introduces 3 new features:

1. Option to hide buffers from `yeet.select_target` entries. 
    - New term buffer option can now be hidden from the `yeet.select_target` list.
    - I didn't create one option for tmux as entries are only shown when tmux is running.

2. Option to create a new tmux window (in the same session) in `yeet.select_target`
    - Currently yeet only allows to create tmux panes but no windows.

3. Option to retry last used target in case of failure. (ex. channel was closed)
    - I usually use tmux panes with yeet, but then I close the pane. So when I run `yeet.execute` I have to re-select again the same option to open a tmux pane.
    - Works with term buffers, tmux panes, tmux windows.
    
This is my first time contributing to an nvim plugin, so please let me know if I missed any guidelines. Also if needed, I can split this pull request into smaller ones.

Things to do:
- ~update readme.md~
- ~update docs (help file)~
- Write tests