### PR TITLE
Added the ability to specify the shell for new Neovim terminals.

### DIFF
--- a/lua/yeet/buffer.lua
+++ b/lua/yeet/buffer.lua
@@ -8,7 +8,7 @@ local M = {}
 function M.new()
     local current = vim.api.nvim_get_current_win()
     vim.cmd("vert split")
-    vim.cmd.terminal()
+    vim.cmd.terminal(require("yeet").config.shell)
 
     local buf = vim.api.nvim_get_current_buf()
 

--- a/lua/yeet/conf.lua
+++ b/lua/yeet/conf.lua
@@ -145,6 +145,7 @@ C.defaults = {
         }
     end,
     custom_eval = nil,
+    shell = nil,
 }
 
 return C

--- a/lua/yeet/init.lua
+++ b/lua/yeet/init.lua
@@ -34,6 +34,7 @@ local M = {
 ---@field cache? fun():string Resolver for cache file.
 ---@field cache_window_opts? table | fun():table win_config passed to |nvim_open_win()|
 ---@field custom_eval?  fun(c:string):string Modifying command string before execution.
+---@field shell? string Specifies the shell command when starting a new Neovim terminal.
 ---@see standard-path
 ---@see uv.cwd
 ---@see vim.api.keyset.win_config


### PR DESCRIPTION
I don't use the stock CMD shell when I run on Windows, so I need to customize yeet's creation of new terminals. I added a simple new `shell` config setting and believe I've updated the code in the plugin correctly to respect it. I'm a little confused by the handling of the `conf` variable in `buffer.lua` as it looks to me like that's never going to have anything but the defaults. But maybe that's intended? Not sure. Whatever the case, please consider integrating this fork to enable users to customize terminal creation from within yeet. Thanks for your consideration.